### PR TITLE
Add gitattributes rule for Markdown normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md text eol=lf


### PR DESCRIPTION
## Summary
- add a .gitattributes entry to normalize Markdown files as text with LF endings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e24888cc8c8321849dba46627aad97