### PR TITLE
Add pagination support for model history endpoint

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -7,6 +7,7 @@ from typing import Callable
 
 from worker.src.storage import JobStorage
 
+from .routes import models as models_routes
 from .schemas.jobs import JobState, JobStatus
 from .services import build_job_stats
 
@@ -32,6 +33,9 @@ def get_storage() -> JobStorage:
 
 if FastAPI is not None:
     app = FastAPI(title="CNE Offline API")
+
+    if models_routes.router is not None:
+        app.include_router(models_routes.router)
 
     @app.get("/api/jobs/{job_id}", response_model=JobStatus)
     async def read_job(job_id: str, storage: JobStorage = Depends(get_storage)) -> JobStatus:

--- a/api/app/routes/__init__.py
+++ b/api/app/routes/__init__.py
@@ -1,0 +1,7 @@
+"""Route exports for FastAPI application."""
+
+from __future__ import annotations
+
+from . import models
+
+__all__ = ["models"]

--- a/api/app/routes/models.py
+++ b/api/app/routes/models.py
@@ -1,0 +1,40 @@
+"""FastAPI routes exposing model registry information."""
+from __future__ import annotations
+
+from typing import Sequence
+
+from ..services.models import RegistryRecord, get_history as get_model_history, load_registry
+
+try:  # pragma: no cover - FastAPI optional dependency
+    from fastapi import APIRouter, Depends, Query
+except ModuleNotFoundError:  # pragma: no cover - fallback for environments without FastAPI
+    APIRouter = None  # type: ignore
+
+    def Depends(factory):  # type: ignore
+        return factory
+
+    def Query(default, **_kwargs):  # type: ignore
+        return default
+
+
+def get_registry() -> Sequence[RegistryRecord]:
+    """Return raw model registry records from persistent storage."""
+
+    return load_registry()
+
+
+if APIRouter is not None:  # pragma: no branch - runtime guard
+    router = APIRouter(prefix="/api/models", tags=["models"])
+
+    @router.get("/history", response_model=None)
+    async def get_history(
+        page: int = Query(1, ge=1, le=100, description="Requested page number"),
+        size: int = Query(20, ge=1, le=100, description="Items per page"),
+        registry: Sequence[RegistryRecord] = Depends(get_registry),
+    ) -> dict:
+        """Return a paginated slice of the model registry history."""
+
+        history = get_model_history(registry, page=page, size=size)
+        return history.to_dict()
+else:  # pragma: no cover - runtime fallback when FastAPI missing
+    router = None

--- a/api/app/schemas/__init__.py
+++ b/api/app/schemas/__init__.py
@@ -1,5 +1,13 @@
 """Schema helper exports for API payloads."""
 
 from .jobs import JobCreated, JobState, JobStats, JobStatus
+from .models import ModelHistory, ModelInfo
 
-__all__ = ["JobCreated", "JobState", "JobStats", "JobStatus"]
+__all__ = [
+    "JobCreated",
+    "JobState",
+    "JobStats",
+    "JobStatus",
+    "ModelHistory",
+    "ModelInfo",
+]

--- a/api/app/schemas/models.py
+++ b/api/app/schemas/models.py
@@ -1,0 +1,42 @@
+"""Schema objects describing model registry payloads."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, List, Mapping, Optional
+
+
+@dataclass
+class ModelInfo:
+    """Metadata describing a single model version."""
+
+    version: str
+    created_at: datetime
+    metrics: Optional[Mapping[str, float]] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {
+            "version": self.version,
+            "created_at": self.created_at.isoformat(),
+        }
+        if self.metrics is not None:
+            payload["metrics"] = dict(self.metrics)
+        return payload
+
+
+@dataclass
+class ModelHistory:
+    """Paginated listing of models stored in the registry."""
+
+    page: int
+    size: int
+    total: int
+    items: List[ModelInfo] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "page": self.page,
+            "size": self.size,
+            "total": self.total,
+            "items": [item.to_dict() for item in self.items],
+        }

--- a/api/app/services/__init__.py
+++ b/api/app/services/__init__.py
@@ -1,5 +1,6 @@
 """Service helpers for the FastAPI backend."""
 
 from .jobs import build_job_stats
+from .models import get_history as get_model_history, load_registry as load_model_registry
 
-__all__ = ["build_job_stats"]
+__all__ = ["build_job_stats", "get_model_history", "load_model_registry"]

--- a/api/app/services/models.py
+++ b/api/app/services/models.py
@@ -1,0 +1,91 @@
+"""Model service helpers for registry pagination."""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import List, Mapping, Sequence, Union
+
+from ..schemas.models import ModelHistory, ModelInfo
+
+RegistryRecord = Union[ModelInfo, Mapping[str, object]]
+
+_DEFAULT_REGISTRY_PATH = Path(os.environ.get("CNE_MODEL_REGISTRY", "data/models/registry.json"))
+
+
+def load_registry(path: Union[str, os.PathLike[str], None] = None) -> Sequence[RegistryRecord]:
+    """Load registry records from disk.
+
+    The registry is expected to be stored as a JSON list. Missing files yield an empty
+    list to make the API resilient in development environments.
+    """
+
+    registry_path = Path(path) if path is not None else _DEFAULT_REGISTRY_PATH
+    if not registry_path.exists():
+        return []
+
+    with registry_path.open("r", encoding="utf-8") as stream:
+        payload = json.load(stream)
+
+    if not isinstance(payload, list):
+        raise ValueError("Model registry must contain a list of records")
+    return payload
+
+
+def _coerce_datetime(value: object) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        normalised = value.replace("Z", "+00:00") if value.endswith("Z") else value
+        try:
+            return datetime.fromisoformat(normalised)
+        except ValueError as exc:  # pragma: no cover - invalid persisted data
+            raise ValueError(f"Invalid ISO datetime string: {value}") from exc
+    raise TypeError("Model registry record is missing a valid 'created_at' value")
+
+
+def _coerce_metrics(value: object) -> Mapping[str, float] | None:
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        return dict(value)
+    raise TypeError("Model registry metrics must be a mapping if provided")
+
+
+def _normalise_record(record: RegistryRecord) -> ModelInfo:
+    if isinstance(record, ModelInfo):
+        return record
+    version = record.get("version") if isinstance(record, Mapping) else None
+    created_at = record.get("created_at") if isinstance(record, Mapping) else None
+    metrics = record.get("metrics") if isinstance(record, Mapping) else None
+    if version is None:
+        raise KeyError("Model registry record missing 'version'")
+    if created_at is None:
+        raise KeyError("Model registry record missing 'created_at'")
+    return ModelInfo(
+        version=str(version),
+        created_at=_coerce_datetime(created_at),
+        metrics=_coerce_metrics(metrics),
+    )
+
+
+def get_history(
+    registry: Sequence[RegistryRecord],
+    *,
+    page: int = 1,
+    size: int = 20,
+) -> ModelHistory:
+    """Return paginated history information for models in the registry."""
+
+    if page < 1:
+        raise ValueError("page must be greater than or equal to 1")
+    if size < 1:
+        raise ValueError("size must be greater than or equal to 1")
+
+    normalised: List[ModelInfo] = [_normalise_record(record) for record in registry]
+    total = len(normalised)
+    start = (page - 1) * size
+    end = start + size
+    items = normalised[start:end]
+    return ModelHistory(page=page, size=size, total=total, items=items)

--- a/tests/test_api_models_history.py
+++ b/tests/test_api_models_history.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List
+
+import pytest
+
+from api.app.schemas.models import ModelInfo
+from api.app.services.models import get_history
+
+
+def _build_records(count: int) -> List[ModelInfo]:
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    records: List[ModelInfo] = []
+    for index in range(count):
+        records.append(
+            ModelInfo(
+                version=f"model-{index}",
+                created_at=base.replace(day=min(base.day + index, 28)),
+                metrics={"acc": 0.9 + index * 0.01},
+            )
+        )
+    return records
+
+
+def test_get_history_paginates_records():
+    records = _build_records(5)
+
+    history = get_history(records, page=2, size=2)
+
+    assert history.page == 2
+    assert history.size == 2
+    assert history.total == 5
+    assert [item.version for item in history.items] == ["model-2", "model-3"]
+
+
+def test_history_route_uses_pagination():
+    pytest.importorskip("fastapi", reason="FastAPI not installed")
+    from fastapi.testclient import TestClient
+
+    from api.app.main import app
+    from api.app.routes import models as models_routes
+
+    records = [
+        {
+            "version": "parser-v1",
+            "created_at": datetime(2024, 1, 1, tzinfo=timezone.utc).isoformat(),
+            "metrics": {"f1": 0.9},
+        },
+        {
+            "version": "parser-v2",
+            "created_at": datetime(2024, 1, 2, tzinfo=timezone.utc).isoformat(),
+            "metrics": {"f1": 0.91},
+        },
+        {
+            "version": "parser-v3",
+            "created_at": datetime(2024, 1, 3, tzinfo=timezone.utc).isoformat(),
+            "metrics": {"f1": 0.92},
+        },
+    ]
+
+    def override_registry():
+        return records
+
+    app.dependency_overrides[models_routes.get_registry] = override_registry
+    client = TestClient(app)
+    response = client.get("/api/models/history", params={"page": 2, "size": 1})
+    app.dependency_overrides.pop(models_routes.get_registry, None)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["page"] == 2
+    assert payload["size"] == 1
+    assert payload["total"] == len(records)
+    assert [item["version"] for item in payload["items"]] == ["parser-v2"]


### PR DESCRIPTION
## Summary
- add dedicated model schemas including pagination metadata for history responses
- paginate model history records in the service layer and expose query parameters through the FastAPI route
- cover the pagination behaviour with unit and API regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e25872c68c8321aeebe80871b5e3d1