### PR TITLE
Ensure OCR confidence metrics remain floats

### DIFF
--- a/tests/test_api_job_stats.py
+++ b/tests/test_api_job_stats.py
@@ -23,7 +23,7 @@ def test_job_status_payload_includes_ocr_conf_mean(tmp_path):
         "rows_ok": 1,
         "rows_warn": 1,
         "rows_err": 0,
-        "ocr_conf_mean": 0.85,
+        "ocr_conf_mean": 1.0,
     }
 
     metadata = storage.mark_state(
@@ -50,7 +50,7 @@ def test_job_status_payload_includes_ocr_conf_mean(tmp_path):
         error=metadata.error,
     ).to_dict()
 
-    assert payload["stats"]["ocr_conf_mean"] == stats["ocr_conf_mean"]
+    assert payload["stats"]["ocr_conf_mean"] == pytest.approx(stats["ocr_conf_mean"])
 
 
 @pytest.mark.skipif(TestClient is None, reason="FastAPI is not available")

--- a/worker/src/storage.py
+++ b/worker/src/storage.py
@@ -66,7 +66,9 @@ def _coerce_stats(raw: Dict[str, object]) -> Dict[str, Union[int, float, None]]:
                 numeric = float(str(value))
             except (TypeError, ValueError):
                 continue
-        if numeric.is_integer():
+        if key == "ocr_conf_mean":
+            stats[key] = float(numeric)
+        elif numeric.is_integer():
             stats[key] = int(numeric)
         else:
             stats[key] = numeric


### PR DESCRIPTION
## Summary
- prevent `ocr_conf_mean` values from being coerced to integers when loading job stats
- adjust the API job stats test to cover a confidence score of 1.0

## Testing
- pytest tests/test_api_job_stats.py tests/test_validator_summary.py tests/test_writer_meta.py

------
https://chatgpt.com/codex/tasks/task_b_68e281b71114832189c516be34ab1ed4