### PR TITLE
Allow stats to retain float metrics

### DIFF
--- a/worker/src/storage.py
+++ b/worker/src/storage.py
@@ -61,17 +61,17 @@ def _coerce_stats(raw: Dict[str, object]) -> Dict[str, Union[int, float, None]]:
             continue
         if isinstance(value, (int, float)):
             numeric = float(value)
+            original_type = type(value)
         else:
             try:
                 numeric = float(str(value))
             except (TypeError, ValueError):
                 continue
-        if key == "ocr_conf_mean":
-            stats[key] = float(numeric)
-        elif numeric.is_integer():
+            original_type = float
+        if original_type is int and numeric.is_integer():
             stats[key] = int(numeric)
         else:
-            stats[key] = numeric
+            stats[key] = float(numeric)
     return stats
 
 


### PR DESCRIPTION
## Summary
- preserve floating point metrics when reloading job stats from disk
- continue exposing integer metrics unchanged while treating floats consistently

## Testing
- pytest tests/test_validator_summary.py tests/test_writer_meta.py tests/test_api_job_stats.py

------
https://chatgpt.com/codex/tasks/task_b_68e284cbcdbc8321a9fe34b69a6c2ab7