### PR TITLE
Improve JobStats serialization for float stats

### DIFF
--- a/api/app/schemas/jobs.py
+++ b/api/app/schemas/jobs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 
 class JobState(str, Enum):
@@ -23,8 +23,8 @@ class JobStats:
     rows_err: Optional[int] = None
     ocr_conf_mean: Optional[float] = None
 
-    def to_dict(self) -> Dict[str, Optional[float]]:
-        payload: Dict[str, Optional[float]] = asdict(self)
+    def to_dict(self) -> Dict[str, Optional[Union[int, float]]]:
+        payload: Dict[str, Optional[Union[int, float]]] = asdict(self)
         return {key: value for key, value in payload.items() if value is not None}
 
 


### PR DESCRIPTION
## Summary
- widen the JobStats serialization typing to cover integer and float statistics
- ensure the API schema metadata can expose floating-point OCR confidence values without casting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e296b1b9f08321bf6a9b95e1735ebc